### PR TITLE
Comment database config options by default (fixes #30)

### DIFF
--- a/config-sample.js
+++ b/config-sample.js
@@ -39,12 +39,13 @@ module.exports = {
   logger: {
     key: 'mixpanel_token'
   },
-  db: {
-    user: 'DB_USER',
-    host: 'DB_HOST',
-    database: 'DB_NAME',
-    password: 'DB_PASSWORD',
-    port: 'DB_PORT',
-  },
+    //  Optional custom database config options for PostgreSQL
+//  db: {
+//    user: 'DB_USER',
+//    host: 'DB_HOST',
+//    database: 'DB_NAME',
+//    password: 'DB_PASSWORD',
+//    port: 'DB_PORT',
+//  },
   max_query_result: 50
 };


### PR DESCRIPTION
This PR comments out the database config options by default in the sample config, so a new user and a CI environment can build the project without erroring.

# Analysis

Thanks to the help of @carloscdias, we discovered why the pre-commit checks were failing. The database options were added to the sample config a while back. If you use them as-is, it overrides the defaults for Postgres. But I figured that a custom Postgres database is likely being used in production.

So, this is a happy medium – the sample config comments out the database config options, and anyone running in a production environment that needs them can uncomment and configure as needed.

This also enables us to move forward with CI in #29!