### PR TITLE
Add contributing guidelines placeholder (closes #23)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+Contributing guidelines
+=======================
+
+See the [MagicBox contributing
+guidelines](https://github.com/unicef/magicbox/blob/master/.github/CONTRIBUTING.md)
+first for general guidelines that apply to _all_ MagicBox projects!
+
+
+## Checklist for magicbox-open-api
+
+Before submitting a new pull request to this repo, follow these steps:
+
+1. Follow [MagicBox contributing
+   guidelines](https://github.com/unicef/magicbox/blob/master/.github/CONTRIBUTING.md)
+2. Run all unit tests (`npm test`)


### PR DESCRIPTION
Adds the same contributing guidelines we have for magicbox-latlon-admin-server. 