### PR TITLE
Beautify swagger (fixes #48)

### DIFF
--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -6,13 +6,13 @@ info:
 <p>
 This API serves information used by the data science team at the Office of Innovation at UNICEF.
 </p>
+
 <p>
 For detailed instructions on how to use this API, please read this <a href='https://medium.com/@mikefabrikant/the-magic-box-wiki-a69e20a1dcfe'>wiki</a>.
 </p>
-<br/><br/>
-  <u>Currently available</u>:
 
 <p>
+Currently available:
 <ul>
   <li>
     Case data from <a href=http://www.paho.org/hq/index.php?option=com_content&view=article&id=12390&Itemid=42090&lang=en>Paho</a>
@@ -29,8 +29,9 @@ For detailed instructions on how to use this API, please read this <a href='http
 <p>
 You can clone and install the <a href='https://github.com/unicef/magicbox-open-api/'>Magic Box API</a> locally, it comes with sample data.  If you would like to generate the same data sets we serve, please go to the the <a href='https://github.com/unicef/magicbox/wiki'>Magic Box Wiki</a>.
 </p>
+
 <p>
-  Most data comes with an admin ID, which is explained <a href='https://github.com/unicef/magicbox-open-api#what-does-this-mean'>here</a>. We will provide the option to request geojson with that data shortly.
+Most data comes with an admin ID, which is explained <a href='https://github.com/unicef/magicbox-open-api#what-does-this-mean'>here</a>. We will provide the option to request geojson with that data shortly.
 </p>
 "
 
@@ -65,7 +66,7 @@ securityDefinitions:
       in: header
 
 x-volos-resources:
-  #Defines our cache
+  # Defines our cache
   cache:
       name: magic-box-cache
       provider: volos-cache-memory
@@ -79,8 +80,8 @@ paths:
     get:
       tags:
         - 'Mobility'
-      description: Returns list of countries for which we have mobility data. Each list entry also has the data's provider name ("source") and the shapefile set name ("shapefile").
-      summary: abw, afg...
+      description: Returns list of countries for which we have mobility data. Each list entry also has the data's provider name ("source"), the shapefile set name ("shapefile"), and the path for app use.
+      summary: List of countries
       # used as the method name of the controller
       operationId: getCountriesAndSourceData
       responses:
@@ -93,7 +94,9 @@ paths:
                                     {
                                     "country": 'col',
                                     "source": 'acme',
-                                    "shapefile": 'santiblanko'
+                                    "shapefile": 'santiblanko',
+                                    "path": '/api/mobility/source/acme/series/santiblanko/countries/col'
+                                    #TODO: prefix the path to reflect the most recent changes
                                     }
                                 ]
                               }
@@ -112,7 +115,7 @@ paths:
       tags:
         - 'Mobility'
       description: Returns list of sources for mobility
-      summary: amadeus, telefonica...
+      summary: List of sources
       # used as the method name of the controller
       operationId: getProperties
       responses:
@@ -120,10 +123,10 @@ paths:
           description: Success
           examples:
             application/json: {
-                                "key": "mosquito",
+                                "key": "mobility",
                                 "properties": [
-                                    "amadeus",
-                                    "telefonica"
+                                    "acme",
+                                    "worldpop"
                                 ]
                               }
           schema:
@@ -140,14 +143,13 @@ paths:
     get:
       tags:
         - 'Mobility'
-      description: Returns list shapefile series
+      description: Returns list of shapefile series
+      summary: List of shapefile series e.g. gadm2-8, santiblanko...
       parameters:
         - name: source
           type: string
           in: path
           required: true
-       # used as the method n
-      summary: gadm2-8, santiblanko...
       # used as the method name of the controller
       operationId: getProperties
       responses:
@@ -175,7 +177,8 @@ paths:
     get:
       tags:
         - 'Mobility'
-      description: Returns list dates with mobility for specified source, shapefile set, country
+      description: Returns list of countries with mobility for specified source and shapefile set
+      summary: List of countries per source and shapefile
       parameters:
         - name: source
           type: string
@@ -185,8 +188,6 @@ paths:
           type: string
           in: path
           required: true
-       # used as the method n
-      summary: gadm2-8, santiblanko...
       # used as the method name of the controller
       operationId: getProperties
       responses:
@@ -213,7 +214,8 @@ paths:
     get:
       tags:
         - 'Mobility'
-      description: Returns list dates with mobility for specified source, shapefile set, country
+      description: Returns list of dates with mobility for specified source, shapefile set, country
+      summary: List of dates per source, shapefile, country
       parameters:
         - name: source
           type: string
@@ -227,8 +229,6 @@ paths:
           type: string
           in: path
           required: true
-       # used as the method n
-      summary: gadm2-8, santiblanko...
       # used as the method name of the controller
       operationId: getProperties
       responses:
@@ -257,7 +257,8 @@ paths:
     get:
       tags:
         - 'Mobility'
-      description: Returns list dates with mobility for specified source, shapefile set, country
+      description: Returns mobility data for specified source, shapefile set, country, date
+      summary: Mobility data per date
       parameters:
         - name: source
           type: string
@@ -275,8 +276,6 @@ paths:
           type: string
           in: path
           required: true
-       # used as the method n
-      summary: gadm2-8, santiblanko...
       # used as the method name of the controller
       operationId: getProperties
       responses:
@@ -284,11 +283,8 @@ paths:
           description: Success
           examples:
             application/json: {
-                                "key": "mosquito",
-                                "properties": [
-                                    "gadm2-8",
-                                    "santiblanko"
-                                ]
+                                "key": "mobility",
+                                "properties":
                               }
           schema:
             # a pointer to a definition
@@ -306,7 +302,7 @@ paths:
       tags:
         - 'Mosquito'
       description: Returns list of mosquito kinds for which data is available
-      summary: aegypti / albopictus
+      summary: List of mosquito kinds e.g. aegypti, albopictus
       # used as the method name of the controller
       operationId: getProperties
       responses:
@@ -334,8 +330,8 @@ paths:
     get:
       tags:
         - 'Mosquito'
-      description: Returns mosquito prevelence metadata for all countries - arg, bra, col...etc. Data sourced from, The global distribution of the arbovirus vectors Aedes aegypti and Ae. albopictus, https://elifesciences.org/articles/08347
-      summary: aegypti / albopictus
+      description: Returns mosquito prevalence metadata for all countries - arg, bra, col...etc. Data sourced from, The global distribution of the arbovirus vectors Aedes aegypti and Ae. albopictus, https://elifesciences.org/articles/08347
+      summary: Prevalence data per mosquito kind, all countries
       parameters:
         - name: kind
           type: string
@@ -382,6 +378,7 @@ paths:
       tags:
         - 'Mosquito'
       description: Returns list of countries for which data regarding specified kind of mosquito is available
+      summary: List of countries given mosquito kind
       parameters:
         - name: kind
           type: string
@@ -416,6 +413,7 @@ paths:
       tags:
         - 'Mosquito'
       description: Returns all metadata regarding mosquito prevalence for requested country - arg, bra, col...etc.  Data sourced from, The global distribution of the arbovirus vectors Aedes aegypti and Ae. albopictus, https://elifesciences.org/articles/08347
+      summary: Mosquito prevalence data per country and kind
       parameters:
         - name: kind
           type: string
@@ -640,7 +638,6 @@ paths:
   #   get:
   #     tags:
   #       - 'Population'
-  #     summary: worldbank - admin 0, worldpop - highest admin level available from worldpop.org
   #     description: Returns list of different sources from which population data is available
   #     # used as the method name of the controller
   #     operationId: getProperties
@@ -718,6 +715,7 @@ paths:
       tags:
         - 'Population'
       description: Returns list of all the countries for which we have population data. For this worldpop is used as default source.
+      summary: List of countries
       # used as the method name of the controller
       operationId: getProperties
       responses:
@@ -749,6 +747,7 @@ paths:
       tags:
         - 'Population'
       description: Returns admin level population at highest admin level available by gadm.org
+      summary: Highest-level population data in a given country
       parameters:
         - name: country
           type: string
@@ -811,7 +810,7 @@ paths:
   #     tags:
   #       - 'Population'
   #     description: Returns list of all the countries for which we have population data from specified source.
-  #     summary: arg, bra, col
+  #     summary: List of countries available from a given source
   #     parameters:
   #       - name: source
   #         type: string
@@ -855,7 +854,6 @@ paths:
   #     tags:
   #       - 'Population'
   #     description: Returns all population metadata for requested country - arg, bra, col...etc.
-  #     summary: arg, bra, col
   #     parameters:
   #       - name: source
   #         type: string
@@ -914,7 +912,7 @@ paths:
       tags:
         - 'Cases'
       description: Returns list of epidemics for which case data is available.
-      summary: zika/epi
+      summary: List of epidemics
       operationId: getProperties
       responses:
         "200":
@@ -941,7 +939,7 @@ paths:
       tags:
         - 'Cases'
       description: Returns list of week-types for specified epidemic.
-      summary: zika/epi
+      summary: List of week-types
       parameters:
         - name: kind
           type: string
@@ -974,7 +972,7 @@ paths:
       tags:
         - 'Cases'
       description: Returns list of weeks for which requested data is available. List has first day of week.
-      summary: zika/epi
+      summary: List of weeks
       parameters:
         - name: kind
           type: string
@@ -1011,8 +1009,8 @@ paths:
     get:
       tags:
         - 'Cases'
-      description: Returns JSON with metadata regarding cases for specified kind. Data sourced from Paho, http://www.paho.org/hq/index.php?option=com_content&view=article&id=12390&Itemid=42090&lang=en
-      summary: zika/epi
+      description: Returns JSON with metadata regarding zika cases for all weeks available.
+      summary: Case metadata for all weeks
       parameters:
         - name: kind
           type: string
@@ -1048,7 +1046,7 @@ paths:
                               }
           schema:
             # a pointer to a definition
-            $ref: "#/definitions/casesResponse"
+            $ref: "#/definitions/CasesResponse"
         # responses may fall through to errors
         default:
           description: Error
@@ -1060,7 +1058,8 @@ paths:
     get:
       tags:
         - 'Cases'
-      description: Returns JSON with metadata regarding zika cases
+      description: Returns JSON with metadata regarding zika cases for a given week
+      summary: Case data per week
       parameters:
         - name: kind
           type: string
@@ -1100,7 +1099,7 @@ paths:
                               }
           schema:
             # a pointer to a definition
-            $ref: "#/definitions/casesResponse"
+            $ref: "#/definitions/CasesResponse"
         # responses may fall through to errors
         default:
           description: Error
@@ -1116,29 +1115,9 @@ paths:
       responses:
         "200":
           description: Success
-          examples:
-            application/json: { "cases": {
-                                  "2016-11-17": {
-                                    "can": {
-                                        "country": "Canada",
-                                        "autochthonous_cases_suspected": 0,
-                                        "autochthonous_cases_confirmed": 0,
-                                        "imported_cases": 374,
-                                        "incidence_rate": 0,
-                                        "deaths": 0,
-                                        "confirmed_congenital": 0,
-                                        "population_x_1k": 36286,
-                                        "congenital_suspected": 0,
-                                        "congenital_probable": 0,
-                                        "gbs_total": 0,
-                                        "gbs_confirmed": 0
-                                    }
-                                  }
-                                }
-                              }
           schema:
             # a pointer to a definition
-            $ref: "#/definitions/casesResponse"
+            $ref: "#/definitions/ValueResponse"
         # responses may fall through to errors
         default:
           description: Error
@@ -1160,29 +1139,9 @@ paths:
       responses:
         "200":
           description: Success
-          examples:
-            application/json: { "cases": {
-                                  "2016-11-17": {
-                                    "can": {
-                                        "country": "Canada",
-                                        "autochthonous_cases_suspected": 0,
-                                        "autochthonous_cases_confirmed": 0,
-                                        "imported_cases": 374,
-                                        "incidence_rate": 0,
-                                        "deaths": 0,
-                                        "confirmed_congenital": 0,
-                                        "population_x_1k": 36286,
-                                        "congenital_suspected": 0,
-                                        "congenital_probable": 0,
-                                        "gbs_total": 0,
-                                        "gbs_confirmed": 0
-                                    }
-                                  }
-                                }
-                              }
           schema:
             # a pointer to a definition
-            $ref: "#/definitions/casesResponse"
+            $ref: "#/definitions/ValueResponse"
         # responses may fall through to errors
         default:
           description: Error
@@ -1204,29 +1163,9 @@ paths:
       responses:
         "200":
           description: Success
-          examples:
-            application/json: { "cases": {
-                                  "2016-11-17": {
-                                    "can": {
-                                        "country": "Canada",
-                                        "autochthonous_cases_suspected": 0,
-                                        "autochthonous_cases_confirmed": 0,
-                                        "imported_cases": 374,
-                                        "incidence_rate": 0,
-                                        "deaths": 0,
-                                        "confirmed_congenital": 0,
-                                        "population_x_1k": 36286,
-                                        "congenital_suspected": 0,
-                                        "congenital_probable": 0,
-                                        "gbs_total": 0,
-                                        "gbs_confirmed": 0
-                                    }
-                                  }
-                                }
-                              }
           schema:
             # a pointer to a definition
-            $ref: "#/definitions/casesResponse"
+            $ref: "#/definitions/ValueResponse"
         # responses may fall through to errors
         default:
           description: Error
@@ -1246,29 +1185,9 @@ paths:
       responses:
         "200":
           description: Success
-          examples:
-            application/json: { "cases": {
-                                  "2016-11-17": {
-                                    "can": {
-                                        "country": "Canada",
-                                        "autochthonous_cases_suspected": 0,
-                                        "autochthonous_cases_confirmed": 0,
-                                        "imported_cases": 374,
-                                        "incidence_rate": 0,
-                                        "deaths": 0,
-                                        "confirmed_congenital": 0,
-                                        "population_x_1k": 36286,
-                                        "congenital_suspected": 0,
-                                        "congenital_probable": 0,
-                                        "gbs_total": 0,
-                                        "gbs_confirmed": 0
-                                    }
-                                  }
-                                }
-                              }
           schema:
             # a pointer to a definition
-            $ref: "#/definitions/casesResponse"
+            $ref: "#/definitions/ValueResponse"
         # responses may fall through to errors
         default:
           description: Error
@@ -1281,7 +1200,7 @@ paths:
       tags:
         - 'Schools'
       description: Returns list of countries with for which we have school data
-      summary: 'List of countries with school data'
+      summary: List of countries
       # used as the method name of the controller
       operationId: getCountriesWithSchools
       responses:
@@ -1312,7 +1231,7 @@ paths:
     get:
       tags:
         - 'Schools'
-      description: Returns list of weeks for which requested data is available. List has first day of week.
+      description: Returns list of schools for a given country.
       summary: Schools in country
       parameters:
         - name: country
@@ -1345,7 +1264,7 @@ paths:
     get:
       tags:
         - 'Schools'
-      description: Returns SchoolResponse
+      description: Returns information about a given school
       summary: School by ID
       parameters:
         - name: school_id
@@ -1403,7 +1322,7 @@ definitions:
         type: 'string'
       population:
         type: object
-  casesResponse:
+  CasesResponse:
     required:
       - kind
       - cases


### PR DESCRIPTION
This goes beyond #48 to correct not only `summary` but also other tags e.g. `example`, JSDoc, etc. to make the code more hygienic.

Now the `summary` on Swagger UI page reflects the information actually returned. Before things were either copied from one method to another or kept generic, so the `summary`s read strange or incorrect.

![image](https://user-images.githubusercontent.com/24497961/41375450-260ec2ea-6f24-11e8-84b0-37a350436158.png)

I tried to correct as many `examples` templates as possible, but there are still a few places where I'm not sure how the JSON object will look e.g. under `getAccess` or `mobility/[...]/{csv}`.